### PR TITLE
[TASK] Maintain composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
 		"GPL-2.0-or-later"
 	],
 	"require": {
-		"typo3/cms-core": "^11.5",
-		"fgtclb/academic-persons": "^0.2.0 | dev-main"
+		"typo3/cms-core": "^11.5 || ^12.4",
+		"fgtclb/academic-persons": "^0.2.0 || ^1.1.0 || 0.*.*@dev || 1.*.*@dev || dev-*@dev"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Main branch of this extension is target towards
TYPO3 v11 and v12 only, following the two-core
version per extension version policy.

Align the composer.json to match this policy.

Used command(s):

```shell
composer require --no-update \
    "typo3/cms-core":"^11.5 || ^12.4" \
    "fgtclb/academic-persons":"^0.2.0 || ^1.1.0 || 0.*.*@dev || 1.*.*@dev || dev-*@dev"
```
