### PR TITLE
[TASK] Introduce publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,90 @@
+name: publish
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    name: Ensure GitHub Release with extension TER artifact and publishing to TER
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    env:
+      TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
+      TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify tag
+        run: |
+          if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
+            echo "ERR: Invalid publish version tag: ${{ github.ref }}"
+            exit 1
+          fi
+
+      - name: Get version
+        id: get-version
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Get comment
+        id: get-comment
+        run: |
+          readonly local releaseCommentPrependBody="$( git tag -l ${{ env.version }} --format '%(contents)' )"
+
+          if [[ -n "${releaseCommentPrependBody// }" ]]; then
+            {
+              echo 'releaseCommentPrependBody<<EOF'
+              echo "$releaseCommentPrependBody"
+              echo EOF
+            } >> "$GITHUB_ENV"
+          fi
+          {
+            echo 'terReleaseNotes<<EOF'
+            echo "[RELEASE] ${{ env.version }}"
+            echo "Notes: https://github.com/fgtclb/academic-persons/releases/tag/${{ env.version }}"
+            echo EOF
+          } >> "$GITHUB_ENV"
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          extensions: intl, mbstring, json, zip, curl
+          tools: composer:v2
+
+      - name: Install tailor
+        run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
+
+      # Note that step will fail when `env.version` does not match the `ext_emconf.php` version.
+      - name: Create local TER package upload artifact
+        run: |
+          php ~/.composer/vendor/bin/tailor create-artefact ${{ env.version }}
+
+      # Note that when release already exists for tag, only files will be uploaded and lets this acting as a
+      # fallback to ensure that a real GitHub release is created for the tag along with extension artifacts.
+      - name: Create release and upload artifacts in the same step
+        uses: softprops/action-gh-release@v2
+        if: ${{startsWith(github.ref, 'refs/tags/') }}
+        with:
+          name: "[RELEASE] ${{ env.version }}"
+          body: "${{ env.releaseCommentPrependBody }}"
+          generate_release_notes: true
+          files: |
+            tailor-version-artefact/${{ env.TYPO3_EXTENSION_KEY }}_${{ env.version }}.zip
+            LICENSE
+          fail_on_unmatched_files: true
+
+      # @todo Currently an issue exists with the TYPO3 Extension Repository (TER) tailor based uploads, which seems to
+      #       be WAF related and the T3O TER Team working on. Allow this step to fail (continue on error) for now until
+      #       issues has been sorted out.
+      #       https://github.com/TYPO3/tailor/issues/82
+      # @todo Enable TER upload after extension has been made public.
+#      - name: Publish to TER
+#        # @todo Remove `continue-on-error` after upload with tailor has been fixed.
+#        continue-on-error: true
+#        run: |
+#          php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.terReleaseNotes }}" ${{ env.version }} \
+#            --artefact=tailor-version-artefact/${{ env.TYPO3_EXTENSION_KEY }}_${{ env.version }}.zip

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 !.Build/Web/.gitkeep
 composer.lock
 *.cache
+
+/tailor-version-artefact/
+/tailor-version-upload/


### PR DESCRIPTION
This change adds a publish GitHub action
workflow to make releasing the extension
more automatic. This is only a preparation
until the extension is made public.

This includes:

* Use tailor to create an upload artifact file.
* Creating an GitHub release on pushed tags,
  if not already existing.
* TER upload artifact file is attached to the
  GitHub release.
* Allow tailor TER publish using the previous
  created artifact pack to fail due to issues
  on the T3O/TER infrastructure. This is added
  in disabled state for now.
* Ignore tailor working folders to ensure they
  are not committed to the repository.
