### PR TITLE
[TASK] Align `ext_emconf.php` with `composer.json`

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,8 +10,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-11.5.99',
-            'academic_persons' => '0.1.0-0.0.0',
+            'typo3' => '11.5.0-12.4.99',
+            'academic_persons' => '0.2.0-1.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Dependency constrainst should be aligned between
`ext_emconf.php` and `composer.json`, otherwise
it would not be ensured to have the same setup
between composer and class installations.
